### PR TITLE
get rid of superfluous call to schedule-recompile

### DIFF
--- a/src/virgil.clj
+++ b/src/virgil.clj
@@ -50,7 +50,6 @@
 
     (doseq [d directories]
       (let [prefix (.getCanonicalPath (io/file d))]
-        (schedule-recompile)
         (when-not (contains? @watches prefix)
           (swap! watches conj prefix)
           (watch-directory (io/file d)


### PR DESCRIPTION
we do call recompile later in that function, so this just resulted in compile
being called twice.