### PR TITLE
Update ASM version to 8.0.1 so Virgil keeps working with newer JDK versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: clojure
 script: lein do clean, test
+dist: xenial
 jdk:
   - oraclejdk7
   - oraclejdk8
   - oraclejdk9
+  - oraclejdk10
+  - oraclejdk11
+  - oraclejdk12
+  - oraclejdk13
+  - oraclejdk14  

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: clojure
 script: lein do clean, test
 dist: xenial
 jdk:
-  - oraclejdk7
-  - oraclejdk8
-  - oraclejdk9
-  - oraclejdk10
+  - openjdk7
+  - openjdk8
+  - openjdk9
+  - openjdk10
   - oraclejdk11
   - oraclejdk12
   - oraclejdk13

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: clojure
 script: lein do clean, test
-dist: precise
+dist: xenial
 jdk:
-  - openjdk7
   - openjdk8
   - openjdk9
   - openjdk10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: clojure
 script: lein do clean, test
-dist: xenial
+dist: precise
 jdk:
   - openjdk7
   - openjdk8

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Now, as if by magic, every time the `.java` files on your `:java-source-paths` c
 
 Happy tarnishing.
 
+### From REPL (for instance, for deps.edn users)
+
+Just require virgil from the REPL and launch it. If the java sources are under the java/ folder:
+
+```clj
+user=> (require 'virgil)
+user=> (virgil/watch "java")
+
 ### Boot
 
 For [Boot](http://boot-clj.com/), add this to your `build.boot`:

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject virgil "0.1.9"
   :license {:name "MIT License"}
-  :dependencies [[org.ow2.asm/asm "7.0"]
+  :dependencies [[org.ow2.asm/asm "8.0.1"]
                  [org.clojure/tools.namespace "0.2.11"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject virgil "0.1.9"
+(defproject virgil "0.1.10"
   :license {:name "MIT License"}
   :dependencies [[org.ow2.asm/asm "8.0.1"]
                  [org.clojure/tools.namespace "0.2.11"]]


### PR DESCRIPTION
- Updates the ASM version. ASM would otherwise would fail with an error:

`unsupported class file major version 57`.

- Updates instructions for deps.edn users (the watch can just be run from the REPL).

### Note

In case this patch is wrong for some reason, I also was able to use virgil with deps.edn by excluding ASM from the deps:

```clj
{:paths
 ["src" "test" "classes" "resources" "java"]

 :deps
 {virgil {:mvn/version "0.1.9" :exclusions [org.ow2.asm/asm] }
  org.ow2.asm/asm {:mvn/version "8.0.1"}}}
```
(note the "java" folder needs to be added to paths too).