### PR TITLE
Namespaces should be reloaded after compilation

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0" :mvn/scope "provided"}
+        org.clojure/tools.namespace {:mvn/version "1.5.0"}
         org.ow2.asm/asm {:mvn/version "9.7"}}
 
  :aliases

--- a/src/virgil/compile.clj
+++ b/src/virgil/compile.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.java.io :as io]
    [virgil.watch :as watch]
+   [clojure.tools.namespace.repl :refer (refresh-all)]
    [virgil.decompile :as decompile]
    [virgil.util :refer [print-diagnostics]]
    [clojure.string :as str])
@@ -154,6 +155,10 @@
      (println "\nCompiling" (count name->source)"Java source files in" directories "...")
      (binding [*print-compiled-classes* verbose?]
        (compile-java options collector name->source))
+     ;; We need to create a thread binding for *ns* so that
+     ;; refresh-all can use in-ns.
+     (binding [*ns* *ns*]
+       (refresh-all))
      (when-let [diags (seq (.getDiagnostics collector))]
        (print-diagnostics diags)
        diags))))


### PR DESCRIPTION
I noticed that when I was using the newer version of Virgil, I had to manually reload the namespace before the recompiled class was available.  Part of the intended workflow is that the updated classes should be immediately available.  I noticed that you removed this functionality when doing the refactor, but I assume that was unintentional?  If not, we can discuss this further.